### PR TITLE
Add automatic QR Code generation for short links

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-google-button": "^0.7.2",
+    "react-qr-code": "^2.0.11",
     "tailwindcss": "^3.2.7",
     "typescript": "4.9.5"
   }

--- a/frontend/src/pages/editLinks/index.tsx
+++ b/frontend/src/pages/editLinks/index.tsx
@@ -4,17 +4,58 @@ import { useState, useEffect } from "react";
 import QRCode from "react-qr-code";
 import { auth } from "@/firebase/init";
 
+const qrCodeWidth = 300;
+const qrCodeMargin = 20;
+
 interface Link {
     _id: any,
     shortUrl: string,
     originalUrl: string,
 }
 
+function download(href: string, name: string) {
+    var a = document.createElement('a');
+
+    a.download = name;
+    a.href = href;
+
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+}
+
+const saveQRCode = (qrCodeID: string) => {
+    // this function was made with help from: https://levelup.gitconnected.com/draw-an-svg-to-canvas-and-download-it-as-image-in-javascript-f7f7713cf81f
+    const qrCodeElement = document.getElementById(qrCodeID);
+    if (qrCodeElement instanceof SVGGraphicsElement) {
+        var svg = qrCodeElement as SVGGraphicsElement;
+        var blob = new Blob([svg.outerHTML], { type: 'image/svg+xml;charset=utf-8' });
+        let URL = window.URL || window.webkitURL || window;
+        let blobURL = URL.createObjectURL(blob);
+        let image = new Image();
+        image.onload = () => {
+            let canvas = document.createElement('canvas');
+            canvas.width = qrCodeWidth + 2 * qrCodeMargin;
+            canvas.height = qrCodeWidth + 2 * qrCodeMargin;
+            let context = canvas.getContext('2d');
+            if (context) {
+                context.fillStyle = 'white';
+                context.fillRect(0, 0, canvas.width, canvas.height);
+                context.drawImage(image, qrCodeMargin, qrCodeMargin, qrCodeWidth, qrCodeWidth);
+            }
+            let png = canvas.toDataURL();
+            download(png, 'qr.png');
+        };
+        image.src = blobURL;
+    }
+    return '';
+}
+
 const LinkCard = ({ shortUrl, originalUrl, _id }: any) => {
     const [edit, setEdit] = useState(false)
     const [short, setShort] = useState(shortUrl)
     const [orig, setOrig] = useState(originalUrl)
-    const [qrVisible, setQrVisible] = useState(false)
+    const [qrModalVisible, setqrModalVisible] = useState(false)
 
     const updateLink = async () => {
         const res = await fetch(`${process.env.SERVER}/links/${_id}`, {
@@ -75,29 +116,33 @@ const LinkCard = ({ shortUrl, originalUrl, _id }: any) => {
                         <button className="btn ml-5" onClick={() => { updateLink(); setEdit(!edit) }}>Save</button>
                     }
                     {!edit &&
-                        <button className="btn ml-5" onClick={() => { setQrVisible(true); }}>QR Code</button>
+                        <button className="btn ml-5" onClick={() => { setqrModalVisible(true); }}>QR Code</button>
                     }
                 </div>
             </div>
-            {qrVisible &&
+            {qrModalVisible &&
                 <div>
                     <input type="checkbox" id="qr-code-modal" className="modal-toggle" />
                     <div className="modal modal-open">
-                        <div className="modal-box relative">
-                            <label htmlFor="qr-code-modal" className="btn btn-sm btn-circle absolute right-2 top-2" onClick={() => setQrVisible(false)}>✕</label>
-                            <h3 className="text-lg font-bold">QR Code for <span className="underline">{document.location.protocol + "//" + document.location.hostname + "/" + shortUrl}</span>:</h3>
-                            <QRCode
-                                size={256}
-                                level={"H"}
-                                style={{ height: "auto", maxWidth: "100%", width: "100%", padding: "20px", backgroundColor: "#ffffff", margin: "20px" }}
-                                value={document.location.protocol + "//" + document.location.hostname + "/" + shortUrl}
-                                viewBox={`0 0 256 256`}
-                            />
+                        <div className="modal-box relative text-center">
+                            <label htmlFor="qr-code-modal" className="btn btn-sm btn-circle absolute right-2 top-2" onClick={() => setqrModalVisible(false)}>✕</label>
+                            <h3 className="text-lg font-bold">QR Code for <span className="underline">{document.location.protocol + "//" + document.location.hostname + "/" + shortUrl}</span></h3>
+                            <div style={{ backgroundColor: "#ffffff", padding: qrCodeMargin, marginTop: qrCodeMargin, marginBottom: qrCodeMargin, marginLeft: "auto", marginRight: "auto", width: qrCodeWidth }}>
+                                <QRCode
+                                    id="qr-code-img"
+                                    size={qrCodeWidth}
+                                    level={"H"}
+                                    style={{ height: "auto", maxWidth: "100%" }}
+                                    value={document.location.protocol + "//" + document.location.hostname + "/" + shortUrl + "?utm_source=qr"}
+                                    viewBox={`0 0 ${qrCodeWidth} ${qrCodeWidth}`}
+                                />
+                            </div>
+                            <button className="btn ml-5" onClick={() => saveQRCode("qr-code-img")}>Save Image</button>
                         </div>
                     </div>
                 </div>
             }
-        </div>
+        </div >
     )
 }
 

--- a/frontend/src/pages/editLinks/index.tsx
+++ b/frontend/src/pages/editLinks/index.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
+import QRCode from "react-qr-code";
 import { auth } from "@/firebase/init";
 
 interface Link {
@@ -13,6 +14,7 @@ const LinkCard = ({ shortUrl, originalUrl, _id }: any) => {
     const [edit, setEdit] = useState(false)
     const [short, setShort] = useState(shortUrl)
     const [orig, setOrig] = useState(originalUrl)
+    const [qrVisible, setQrVisible] = useState(false)
 
     const updateLink = async () => {
         const res = await fetch(`${process.env.SERVER}/links/${_id}`, {
@@ -72,8 +74,29 @@ const LinkCard = ({ shortUrl, originalUrl, _id }: any) => {
                     {edit &&
                         <button className="btn ml-5" onClick={() => { updateLink(); setEdit(!edit) }}>Save</button>
                     }
+                    {!edit &&
+                        <button className="btn ml-5" onClick={() => { setQrVisible(true); }}>QR Code</button>
+                    }
                 </div>
             </div>
+            {qrVisible &&
+                <div>
+                    <input type="checkbox" id="qr-code-modal" className="modal-toggle" />
+                    <div className="modal modal-open">
+                        <div className="modal-box relative">
+                            <label htmlFor="qr-code-modal" className="btn btn-sm btn-circle absolute right-2 top-2" onClick={() => setQrVisible(false)}>✕</label>
+                            <h3 className="text-lg font-bold">QR Code for <span className="underline">{document.location.protocol + "//" + document.location.hostname + "/" + shortUrl}</span>:</h3>
+                            <QRCode
+                                size={256}
+                                level={"H"}
+                                style={{ height: "auto", maxWidth: "100%", width: "100%", padding: "20px", backgroundColor: "#ffffff", margin: "20px" }}
+                                value={document.location.protocol + "//" + document.location.hostname + "/" + shortUrl}
+                                viewBox={`0 0 256 256`}
+                            />
+                        </div>
+                    </div>
+                </div>
+            }
         </div>
     )
 }


### PR DESCRIPTION
## Overview

QR images are generated dynamically on client-side so we don't have the overhead of storing them on our backend. Images are not generated until popup is opened for performance purposes.

## Changes Made

- Add qr code button + modal popup on edit page for each link
- Add ability to download QR images
- Added UTM source "qr" for future tracking

## Next Steps

- Show QR code immediately after link is created
- Add tracking of shortlink usage, and track "qr" source to see specifically when someone scanned the QR code

## Screenshots

<details>

  <summary>QR popup button on edit page</summary>

  <img width="715" alt="image" src="https://user-images.githubusercontent.com/75463135/221974638-83916517-450b-452f-8b67-9c79ebab9008.png">

</details>

<details>

  <summary>QR popup when button is pressed</summary>
  
  <img width="516" alt="image" src="https://user-images.githubusercontent.com/75463135/221974993-9b290e06-a826-4c2f-8590-465f8e0071eb.png">

</details>
